### PR TITLE
Re-add compatibility for Python 3.9

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,34 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python package
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest pytest-mpl pytest-cov
+        pip install -r requirements.txt
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,8 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest pytest-mpl pytest-cov
-        pip install -r requirements.txt
+        python -m pip install -e .[tests]
     - name: Test with pytest
       run: |
         pytest

--- a/matplotlib_set_diagrams/_diagram_classes.py
+++ b/matplotlib_set_diagrams/_diagram_classes.py
@@ -29,6 +29,7 @@ from typing import (
     Optional,
     Callable,
     Mapping,
+    Union,
 )
 from numpy.typing import NDArray
 from matplotlib.typing import ColorType
@@ -152,9 +153,9 @@ class SetDiagram:
             subset_geometries : Mapping[Tuple[bool], ShapelyPolygon],
             subset_colors     : Mapping[Tuple[bool], NDArray],
             ax                : plt.Axes,
-    ) -> dict[Tuple[bool], plt.Polygon | PolyCollection]:
+    ) -> dict[Tuple[bool], Union[plt.Polygon, PolyCollection]]:
         """Draw each subset as a separate polygon patch."""
-        subset_artists : dict[Tuple[bool], plt.Polygon | PolyCollection] = dict()
+        subset_artists : dict[Tuple[bool], Union[plt.Polygon, PolyCollection]] = dict()
         for subset, geometry in subset_geometries.items():
             if geometry.area > 0:
                 if isinstance(geometry, ShapelyPolygon):
@@ -283,9 +284,9 @@ class EulerDiagram(SetDiagram):
 
     def __init__(
             self,
-            subset_sizes            : Mapping[Tuple[bool], int | float],
+            subset_sizes            : Mapping[Tuple[bool], Union[int, float]],
             subset_labels           : Optional[Mapping[Tuple[bool], str]]       = None,
-            subset_label_formatter  : Callable[[Tuple[bool], int | float], str] = lambda subset, size : str(size),
+            subset_label_formatter  : Callable[[Tuple[bool], Union[int, float]], str] = lambda subset, size : str(size),
             set_labels              : Optional[list[str]]                       = None,
             set_colors              : Optional[list[ColorType]]                 = None,
             cost_function_objective : str                                       = "inverse",
@@ -316,7 +317,7 @@ class EulerDiagram(SetDiagram):
 
     def _get_layout(
             self,
-            subset_sizes : Mapping[Tuple[bool], int | float],
+            subset_sizes : Mapping[Tuple[bool], Union[int, float]],
             cost_function_objective : str,
             verbose : bool
     ) -> Tuple[NDArray, NDArray]:
@@ -327,14 +328,14 @@ class EulerDiagram(SetDiagram):
         return origins, radii
 
 
-    def _initialize_layout(self, subset_sizes : Mapping[Tuple[bool], int | float]) -> Tuple[NDArray, NDArray]:
+    def _initialize_layout(self, subset_sizes : Mapping[Tuple[bool], Union[int, float]]) -> Tuple[NDArray, NDArray]:
         set_sizes = self._get_set_sizes(subset_sizes)
         radii = self._initialize_radii(set_sizes)
         origins = self._initialize_origins(radii)
         return origins, radii
 
 
-    def _get_set_sizes(self, subset_sizes : Mapping[Tuple[bool], int | float]) -> NDArray:
+    def _get_set_sizes(self, subset_sizes : Mapping[Tuple[bool], Union[int, float]]) -> NDArray:
         """Compute the size of each set based on the sizes of its constituent sub-sets"""
         return np.sum([size * np.array(subset) for subset, size in subset_sizes.items()], axis=0)
 
@@ -370,7 +371,7 @@ class EulerDiagram(SetDiagram):
 
     def _optimize_layout(
             self,
-            subset_sizes : Mapping[Tuple[bool], int | float],
+            subset_sizes : Mapping[Tuple[bool], Union[int, float]],
             origins      : NDArray,
             radii        : NDArray,
             objective    : str,
@@ -448,8 +449,8 @@ class EulerDiagram(SetDiagram):
 
     def _get_subset_labels(
             self,
-            subset_sizes : Mapping[Tuple[bool], int | float],
-            formatter    : Callable[[Tuple[bool], int | float], str],
+            subset_sizes : Mapping[Tuple[bool], Union[int, float]],
+            formatter    : Callable[[Tuple[bool], Union[int, float]], str],
     ) -> dict[Tuple[bool], str]:
         """Map subset sizes to strings using the provided formatter."""
         subset_labels = dict()
@@ -458,7 +459,7 @@ class EulerDiagram(SetDiagram):
         return subset_labels
 
 
-    def _hide_empty_subsets(self, subset_sizes : Mapping[Tuple[bool], int | float]) -> None:
+    def _hide_empty_subsets(self, subset_sizes : Mapping[Tuple[bool], Union[int, float]]) -> None:
         """If the layout routine assigned a non-zero area to a zero-size subset, hide it."""
         for subset, size in subset_sizes.items():
             if (size == 0) & (self.subset_geometries[subset].area > 0):
@@ -760,9 +761,9 @@ class VennDiagram(EulerDiagram):
 
     def __init__(
             self,
-            subset_sizes            : Mapping[Tuple[bool], int | float],
+            subset_sizes            : Mapping[Tuple[bool], Union[int, float]],
             subset_labels           : Optional[Mapping[Tuple[bool], str]]       = None,
-            subset_label_formatter  : Callable[[Tuple[bool], int | float], str] = lambda subset, size : str(size),
+            subset_label_formatter  : Callable[[Tuple[bool], Union[int, float]], str] = lambda subset, size : str(size),
             set_labels              : Optional[list[str]]                       = None,
             set_colors              : Optional[list[ColorType]]                 = None,
             ax                      : Optional[plt.Axes]                        = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
             "Programming Language :: Python :: 3",
             "Topic :: Scientific/Engineering :: Visualization",
 ]
-requires-python = ">3.6"
+requires-python = ">=3.9"
 dependencies = [
                "numpy",
                "scipy", 


### PR DESCRIPTION
Replace pipe operator by `typing.Union` to enable Python 3.9 compatibility.

- Fix #2.
- Introduce a testing workflow for all supported Python versions.
- Update requires-python in pyproject.toml